### PR TITLE
Translate French comments in models

### DIFF
--- a/vinylkeeper_back/app/core/config_env.py
+++ b/vinylkeeper_back/app/core/config_env.py
@@ -38,5 +38,5 @@ class Settings(BaseSettings):
     class Config:
         env_file = f"../api/.env.{os.getenv('APP_ENV', 'development')}"
 
-# Initialiser les paramètres
+# Initialize settings
 settings = Settings()

--- a/vinylkeeper_back/app/models/album_model.py
+++ b/vinylkeeper_back/app/models/album_model.py
@@ -50,7 +50,7 @@ class Album(Base):
         lazy="selectin"
     )
 
-    # Relations many-to-many optimisées
+    # Optimized many-to-many relationships
     collections = relationship(
         "Collection",
         secondary="collection_album",
@@ -70,7 +70,7 @@ class Album(Base):
         cascade="all, delete-orphan"
     )
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "length(title) >= 1",

--- a/vinylkeeper_back/app/models/artist_model.py
+++ b/vinylkeeper_back/app/models/artist_model.py
@@ -32,7 +32,7 @@ class Artist(Base):
         index=True
     )  # MBID
 
-    # Relations optimisées
+    # Optimized relationships
     albums = relationship(
         "Album",
         back_populates="artist",
@@ -52,7 +52,7 @@ class Artist(Base):
         cascade="all, delete-orphan"
     )
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "length(name) >= 1",

--- a/vinylkeeper_back/app/models/collection_model.py
+++ b/vinylkeeper_back/app/models/collection_model.py
@@ -37,7 +37,7 @@ class Collection(Base):
         lazy="selectin"
     )
 
-    # Relations many-to-many optimisées
+    # Optimized many-to-many relationships
     albums = relationship(
         "Album",
         secondary=collection_album,
@@ -51,7 +51,7 @@ class Collection(Base):
         lazy="selectin"
     )
 
-    # Relation many-to-many pour les likes
+    # Many-to-many relation for likes
     liked_by = relationship(
         "User",
         secondary="collection_likes",
@@ -62,7 +62,7 @@ class Collection(Base):
     registered_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "length(name) >= 1",

--- a/vinylkeeper_back/app/models/like_model.py
+++ b/vinylkeeper_back/app/models/like_model.py
@@ -35,12 +35,12 @@ class CollectionLike(Base):
     user = relationship(
         "User",
         back_populates="liked_collections",
-        lazy="selectin"  # Optimise le chargement des likes
+        lazy="selectin"  # Optimize like loading
     )
     collection = relationship(
         "Collection",
         back_populates="liked_by",
-        lazy="selectin"  # Optimise le chargement des likes
+        lazy="selectin"  # Optimize like loading
     )
 
     # Ensure a user can only like a collection once

--- a/vinylkeeper_back/app/models/loan_model.py
+++ b/vinylkeeper_back/app/models/loan_model.py
@@ -53,7 +53,7 @@ class Loan(Base):
         nullable=False
     )
 
-    # Relations optimisées
+    # Optimized relationships
     user = relationship(
         "User",
         back_populates="loans",
@@ -65,7 +65,7 @@ class Loan(Base):
         lazy="selectin"
     )
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "length(borrower_name) >= 1",

--- a/vinylkeeper_back/app/models/place_model.py
+++ b/vinylkeeper_back/app/models/place_model.py
@@ -74,7 +74,7 @@ class Place(Base):
         nullable=False
     )
 
-    # Relations optimisées
+    # Optimized relationships
     submitted_by = relationship(
         "User",
         back_populates="submitted_places",
@@ -87,7 +87,7 @@ class Place(Base):
         cascade="all, delete-orphan"
     )
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "length(name) >= 1",

--- a/vinylkeeper_back/app/models/user_model.py
+++ b/vinylkeeper_back/app/models/user_model.py
@@ -84,11 +84,11 @@ class User(Base):
         nullable=False
     )
 
-    # Relations optimisées avec lazy loading approprié
+    # Optimized relationships with proper lazy loading
     role = relationship(
         "Role",
         back_populates="users",
-        lazy="selectin"  # Charge le rôle immédiatement avec l'utilisateur
+        lazy="selectin"  # Eagerly load role with user
     )
     collections = relationship(
         "Collection",
@@ -133,7 +133,7 @@ class User(Base):
         """Validate timezone format."""
         if value is None:
             raise ValueError("Timezone cannot be null")
-        # Vérification basique du format timezone
+        # Basic timezone format check
         if not value or '/' not in value:
             raise ValueError("Invalid timezone format")
         return value

--- a/vinylkeeper_back/app/models/wishlist_model.py
+++ b/vinylkeeper_back/app/models/wishlist_model.py
@@ -43,7 +43,7 @@ class Wishlist(Base):
         nullable=False
     )
 
-    # Relations optimisées
+    # Optimized relationships
     user = relationship(
         "User",
         back_populates="wishlist_items",
@@ -60,7 +60,7 @@ class Wishlist(Base):
         lazy="selectin"
     )
 
-    # Contraintes de validation
+    # Validation constraints
     __table_args__ = (
         CheckConstraint(
             "(album_id IS NOT NULL AND artist_id IS NULL) OR (album_id IS NULL AND artist_id IS NOT NULL)",


### PR DESCRIPTION
## Summary
- translate leftover French comments into English across backend models
- update config_env comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428cf3eb448328b1bad421f8aec96b